### PR TITLE
Add unit tests using RSpec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--require spec_helper
+--color
+--format documentation
+

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gem 'line-bot-api'
 gem 'json'
 gem 'sinatra'
 gem 'puma'
+
+group :test do
+  gem 'rspec'
+  gem 'rack-test'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    diff-lcs (1.5.0)
     json (2.6.3)
     line-bot-api (1.26.0)
     mustermann (3.0.0)
@@ -11,6 +12,21 @@ GEM
     rack (2.2.5)
     rack-protection (3.0.5)
       rack
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     ruby2_keywords (0.0.5)
     sinatra (3.0.5)
       mustermann (~> 3.0)
@@ -27,6 +43,8 @@ DEPENDENCIES
   json
   line-bot-api
   puma
+  rack-test
+  rspec
   sinatra
 
 BUNDLED WITH

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -5,6 +5,10 @@ require 'json'
 require_relative 'line_bot'
 
 class App < Sinatra::Base
+  get '/' do
+    'Hello World!'
+  end
+
   post '/callback' do
     body = request.body.read
 

--- a/lib/line_bot.rb
+++ b/lib/line_bot.rb
@@ -1,5 +1,5 @@
 require 'line/bot'
-# Comment out for development
+# Remove comment for development
 # require 'dotenv/load'
 
 class LineBot
@@ -14,8 +14,8 @@ class LineBot
     'barber': ['KRISTIAN NOEL PATRICIO!', 'Tawag ka KRISTIAN NOEL PATRICIO!', 'Pagupit nga KRISTIAN NOEL PATRICIO!'],
     'barbero': ['KRISTIAN NOEL PATRICIO!', 'Tawag ka KRISTIAN NOEL PATRICIO!', 'Pagupit nga KRISTIAN NOEL PATRICIO!'],
     'barbers': ['KRISTIAN NOEL PATRICIO!', 'Tawag ka KRISTIAN NOEL PATRICIO!', 'Pagupit nga KRISTIAN NOEL PATRICIO!'],
-    'hi': ['Hello! kamusta na 2mb mong brains?'],
-    'hello': ['Hello! kamusta na 2mb mong brains?'],
+    'hi': ['Hello! Kamusta na 2mb mong brains?'],
+    'hello': ['Hello! Kamusta na 2mb mong brains?'],
     'pogi': ['Eguls', 'Tawag ka Martin', 'Tawag ka Renz'],
     'kalbo': ['Kririn!'],
     'tropa': ['Sino tropa nun?', 'Tropa ba talaga?'],
@@ -66,21 +66,11 @@ class LineBot
 
     keyword = get_keyword(ACCEPTED_KEYWORDS.keys, message)
 
-    if keyword
-			ACCEPTED_KEYWORDS[keyword].sample
-    else
-		  'Di ko gets masyadong pang low level.'
-    end
+    generate_reply(keyword)
 	end
 
 	def self.send_bot_message(message, client, event)
-		# Log prints for debugging
-		p 'Bot message sent!'
-		p event['replyToken']
-		p client
-
 		message = { type: 'text', text: message }
-		p message
 
 		client.reply_message(event['replyToken'], message)
 		'OK'
@@ -94,4 +84,7 @@ class LineBot
     keywords.find { |keyword| Regexp.new(KEYWORD_STR_REGEX % keyword).match?(message) }
   end
 
+  def self.generate_reply(keyword)
+    keyword ? ACCEPTED_KEYWORDS[keyword].sample : 'Di ko gets masyadong pang low level.'
+  end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1,0 +1,9 @@
+require 'app'
+
+describe 'get /' do
+  it 'responds with ok' do
+    get '/'
+
+    expect(last_response.body).to eq "Hello World!"
+  end
+end

--- a/spec/line_bot_spec.rb
+++ b/spec/line_bot_spec.rb
@@ -1,0 +1,51 @@
+require 'app'
+
+describe '#client' do
+  let(:client) { LineBot.client }
+
+  it 'initializes a bot client' do
+    expect(client).to be_instance_of(Line::Bot::Client)
+  end
+end
+
+describe '#is_keyword_in_message?' do
+  context 'Message with an accepted keyword' do
+    it 'returns true' do
+      expect(LineBot.is_keyword_in_message?(LineBot::ACCEPTED_KEYWORDS.keys, 'hi!')).to be true
+    end
+  end
+
+  context 'Message with an unaccepted keyword' do
+    it 'returns false' do
+      expect(LineBot.is_keyword_in_message?(LineBot::ACCEPTED_KEYWORDS.keys, 'random')).to be false
+    end
+  end
+end
+
+describe '#bot_reply_to' do
+  context 'Message with an accepted keyword' do
+    it 'returns true' do
+      expect(LineBot.bot_reply_to('hi!')).to include('Hello! Kamusta na 2mb mong brains?')
+    end
+  end
+
+  context 'Message with an unaccepted keyword' do
+    it 'returns false' do
+      expect(LineBot.bot_reply_to('random')).to eq('')
+    end
+  end
+end
+
+describe '#get_keyword' do
+  context 'Message with an accepted keyword' do
+    it 'returns the correct reply' do
+      expect(LineBot.get_keyword(LineBot::ACCEPTED_KEYWORDS.keys, 'hi!')).to eq(:hi)
+    end
+  end
+
+  context 'Message with an unaccepted keyword' do
+    it 'returns an empty string' do
+      expect(LineBot.get_keyword(LineBot::ACCEPTED_KEYWORDS.keys, 'random')).to eq(nil)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+require 'rack/test'
+require 'rspec'
+require 'pry'
+
+require File.expand_path "../../lib/app", __FILE__
+
+ENV['RACK_ENV'] = 'test'
+
+module RSpecMixin
+  include Rack::Test::Methods
+
+  def app
+    App
+  end
+end
+
+RSpec.configure { |c| c.include RSpecMixin } 


### PR DESCRIPTION
Changes:
1. Added `rspec`, `puma` and `rack-test` to Gemfile to be able to add RSpec.
2. Ran `bundle install` to update `Gemfile.lock`.
3. Add unit tests for `LineBot`.
4. Extract reply generation from `#send_bot_message` to its own method.
5. Code cleanup and typo fixes.